### PR TITLE
Fix Filter Options Packet byte packing.

### DIFF
--- a/anpp_packets/an_packet_186.py
+++ b/anpp_packets/an_packet_186.py
@@ -70,7 +70,7 @@ class FilterOptionsPacket:
     ID = PacketID.filter_options
     LENGTH = 17
 
-    _structure = struct.Struct("<BBBxBBBBBB7x")
+    _structure = struct.Struct("<9B8x")
 
     def decode(self, an_packet: ANPacket) -> int:
         """Decode ANPacket to Filter Options Packet


### PR DESCRIPTION
Make byte packing for FilterOptionsPacket match the definition found in the Spatial Reference Manual.